### PR TITLE
Get file upload connected to cleaning function

### DIFF
--- a/Shiny_App/helper.R
+++ b/Shiny_App/helper.R
@@ -1,0 +1,35 @@
+# (Add description of function here)
+efficacy_function <- function(efficacy_df){
+  efficacy_clean <- efficacy_df %>% 
+    select(Protocol_Animal, Compound, Group, Drug_Dose, Days_Treatment,
+           Treatment_Interval,Elung,Espleen) %>% 
+    rename(lung_efficacy = Elung,
+           spleen_efficacy = Espleen,
+           dosage = Drug_Dose,
+           days_treatment = Days_Treatment,
+           dose_interval = Treatment_Interval,
+           drug = Compound) %>%
+    mutate(lung_efficacy = as.numeric(lung_efficacy)) %>% 
+    mutate(spleen_efficacy = as.numeric(spleen_efficacy)) %>%
+    mutate(dose_interval = as.factor(dose_interval)) %>%
+    mutate(days_treatment = as.factor(days_treatment)) %>% 
+    group_by(Protocol_Animal, drug, Group, dosage, days_treatment, dose_interval) %>% 
+    summarize(lung_efficacy_log = log10(lung_efficacy),
+              spleen_efficacy_log = log10(spleen_efficacy))
+  
+  levels(efficacy_clean$dose_interval)[levels(efficacy_clean$dose_interval)=="Pre Rx 9 week"] <- "_Baseline"
+  levels(efficacy_clean$dose_interval)[levels(efficacy_clean$dose_interval)=="M-F"] <- "_QID"
+  levels(efficacy_clean$dose_interval)[levels(efficacy_clean$dose_interval)=="4 wk"] <- "20_Control"
+  levels(efficacy_clean$dose_interval)[levels(efficacy_clean$dose_interval)=="8 wk"] <- "40_Control"
+  levels(efficacy_clean$drug)[levels(efficacy_clean$drug)==""] <- "Baseline"
+  
+  
+  efficacy_clean <- efficacy_clean %>% 
+    unite(days_dose, days_treatment, dose_interval, sep = "") %>% 
+    separate(days_dose, c("days", "dose"), sep = "_") %>% 
+    rename("days_treatment" = days,
+           "dose_interval" = dose) %>% 
+    mutate(days_treatment = as.numeric(days_treatment))
+
+  return(efficacy_clean)
+}


### PR DESCRIPTION
@KatieKey: This added code gets the file upload connected with the cleaning function you have. You should be able to do something similar for other file uploads. I've added a panel with "Raw Data" to show exactly what's uploaded, as that might be useful for the user to see exactly what they put in. Also, I put panel tabs within the panels that show data, so that users can click through all the different files. 

In the original code, the main problem was that the input you get from the "Upload" widget is really just the file path to the uploaded file, not a file that's been read in by `read_excel` or anything. So, you were missing a step to get from the file upload to what you needed to input to your cleaning function. Once that was resolved, there was also a quirky issue with using `read_excel` with this output from a Shiny Upload widget. I included the web address to a Stack Overflow question that discusses this in the code comments. Evidently, you need to add back on the ".xlsx" file extension to get the `read_excel` function to work correctly with the Shiny file upload.